### PR TITLE
Deny all clippy lints and missing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# seraph
+# Seraph
 
 A Matrix bot API in Rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+//! # Seraph
+//!
+//! Seraph is an idiomatic, async [Matrix](https://matrix.org) bot API library.
+
+#![deny(clippy::all)]
+#![deny(missing_docs)]
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
This commit sets global flags to treat Clippy lints as errors, and disallow undocumented public items. Initial crate-level documentation was also added to satisfy these requirements.

These mandates can be bypassed for individual items using attributes such as `#[allow(clippy::<lint>)]`, `#[allow(missing_docs)]`, and `#[doc(hidden)]`.